### PR TITLE
Unbreak the buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,12 +7,7 @@ RESET='\033[0m'
 
 echo -e "${YELLOW}WARNING: This buildpack is no longer maintained."
 echo -e
-echo -e "Please choose a different buildpack or go to https://github.com/ddollar/heroku-buildpack-multi"
-echo "and fork it to your own account."
-echo -e
-echo -e "This buildpack will cease to function at the stroke of midnight on January 1, 2017.${RESET}"
-
-[ $(date +%Y%m%d%H%M%S) -gt "20170101000000" ] && exit 1
+echo -e "Please choose a different buildpack."
 
 function indent() {
   c='s/^/       /'


### PR DESCRIPTION
The builpack has a built-in bomb of refusing to work after Jan 1, 2017 which broke our unified build.